### PR TITLE
Add a dockerfile for easier distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.7 
+
+COPY . /src/pysdd/
+
+RUN  pip install cysignals numpy cython && \
+     cd /src/pysdd && \
+     make build && \
+     python setup.py install && \
+     cd /src && \
+     rm -rf pysdd
+
+WORKDIR /src
+
+CMD /bin/bash
+


### PR DESCRIPTION
I had some difficulty getting this library installed properly on my system so I wrote a simple Docker file that handles it correctly to make it easier to use if docker is an option. 